### PR TITLE
Typo in answers.ipynb 

### DIFF
--- a/answers.ipynb
+++ b/answers.ipynb
@@ -145,7 +145,7 @@
     "\n",
     "Write a function `mse` which estimates the mean squared error (MSE) $\\mathbb{E}[\\|X * \\hat{b} - y\\|_2^2]$.\n",
     "\n",
-    "The function should have the call signature `mse(b, bhat, N=100, sig=0.1)`  You can generate `X` to be `N x p` using `np.random.randn`, and set `y = X * b + sig * np.random.randn(p)` (use the same value of `sig` that you use when generating the data).  You can then estimate the MSE by computing $\\frac{1}{N}\\|X * \\hat{b} - y\\|_2^2$\n",
+    "The function should have the call signature `mse(b, bhat, N=100, sig=0.1)`  You can generate `X` to be `N x p` using `np.random.randn`, and set `y = X * b + sig * np.random.randn(N)` (use the same value of `sig` that you use when generating the data).  You can then estimate the MSE by computing $\\frac{1}{N}\\|X * \\hat{b} - y\\|_2^2$\n",
     "\n",
     "Create a plot of the MSE vs the noise parameter `sig` (use the same value of `sig` when generating data and computing the MSE).  Put `sig` on a logartihmic axis ranging from `1e-4` to `10`.  Use `n=100`, `p=50` when generating data, and `N=100` when computing the MSE.  Put your plot on log-log axes.  Give it a title and axis labels."
    ]


### PR DESCRIPTION
In Problem 0 under “Estimate the Mean Squared Error,” the equation should should be 

> y = X * b + sig * np.random.randn(N)

Instead, the equation currently reads as follows.

> y = X * b + sig * np.random.randn(p)
